### PR TITLE
feat(lint): read runtime module list from wheel manifest

### DIFF
--- a/.github/workflows/publish-template-image.yml
+++ b/.github/workflows/publish-template-image.yml
@@ -99,16 +99,45 @@ jobs:
         # package. This bit claude-code (5 imports), langgraph,
         # deepagents, and gemini-cli on 2026-04-27 — each one a
         # separate workspace-stuck-in-provisioning incident.
-        # The set of names mirrors workspace/*.py basenames at the time
-        # this lint was added; if a new runtime module ships, the
-        # build will fail loud with a clear message instead of
-        # silently shipping broken templates. Fail-fast: this runs
-        # before docker login + buildx setup so a bad PR returns red
-        # in seconds, not minutes.
+        #
+        # Source of truth: molecule_runtime/_runtime_modules.json
+        # inside the published wheel (emitted by
+        # scripts/build_runtime_package.py). Pulling the manifest
+        # from PyPI's latest wheel ensures the lint never drifts from
+        # the rewriter's actual closed list. If the manifest can't be
+        # fetched (older wheel, PyPI down, etc.), falls back to the
+        # inline list — known to be correct as of 2026-04-27 — so
+        # the lint never silently passes on a fetch failure.
+        #
+        # Fail-fast: this runs before docker login + buildx setup so
+        # a bad PR returns red in seconds, not minutes.
         shell: bash
         run: |
           set -eu
-          RUNTIME_MODULES='plugins|adapter_base|config|main|preflight|prompt|coordinator|consolidation|events|heartbeat|transcript_auth|runtime_wedge|watcher|skill_loader|policies|adapters|builtin_tools|executor_helpers|a2a_executor|a2a_client|a2a_tools|a2a_cli|a2a_mcp_server|agent|agents_md|initial_prompt|molecule_ai_status|platform_auth|shared_runtime'
+
+          # Fallback list — used only when the manifest fetch fails.
+          # Mirrors scripts/build_runtime_package.py:TOP_LEVEL_MODULES
+          # at the time this comment was written.
+          FALLBACK_MODULES='plugins|adapter_base|config|main|preflight|prompt|coordinator|consolidation|events|heartbeat|transcript_auth|runtime_wedge|watcher|skill_loader|policies|adapters|builtin_tools|executor_helpers|a2a_executor|a2a_client|a2a_tools|a2a_cli|a2a_mcp_server|agent|agents_md|initial_prompt|molecule_ai_status|platform_auth|shared_runtime'
+
+          RUNTIME_MODULES=""
+          mkdir -p /tmp/runtime-wheel
+          if pip download --quiet molecule-ai-workspace-runtime --no-deps -d /tmp/runtime-wheel 2>/dev/null; then
+            WHEEL=$(ls /tmp/runtime-wheel/*.whl 2>/dev/null | head -1)
+            if [ -n "$WHEEL" ]; then
+              # Pull both top_level + subpackage names; both can be bare-imported.
+              RUNTIME_MODULES=$(unzip -p "$WHEEL" molecule_runtime/_runtime_modules.json 2>/dev/null \
+                | python3 -c "import sys,json; m=json.load(sys.stdin); print('|'.join(sorted(set(m['top_level_modules']) | set(m['subpackages']))))" 2>/dev/null || echo "")
+            fi
+          fi
+
+          if [ -n "$RUNTIME_MODULES" ]; then
+            echo "::notice::lint module list pulled from molecule-ai-workspace-runtime wheel manifest"
+          else
+            RUNTIME_MODULES="$FALLBACK_MODULES"
+            echo "::warning::could not read _runtime_modules.json from PyPI wheel — using inline fallback list"
+          fi
+
           # Match `from <module> import` at start of line OR after any whitespace
           # (function-scope imports inside if/try blocks count too).
           if HITS=$(grep -nE "^\s*from (${RUNTIME_MODULES}) import" *.py 2>/dev/null); then


### PR DESCRIPTION
## Summary
Switches the publish-template-image bare-imports lint from a hardcoded inline list to the \`_runtime_modules.json\` manifest emitted by [molecule-core's build_runtime_package.py](https://github.com/Molecule-AI/molecule-core/pull/2174).

Single source of truth for the runtime module list. Tonight surfaced that the same closed list lived in three places that drifted independently:
1. \`molecule-core/scripts/build_runtime_package.py:TOP_LEVEL_MODULES\` (the rewriter — authoritative)
2. \`molecule-ci/.github/workflows/publish-template-image.yml\` (the lint — hardcoded mirror)
3. \`molecule-core/.github/workflows/publish-runtime.yml\` (smoke — indirect via \`import molecule_runtime.main\`)

## Implementation
- \`pip download molecule-ai-workspace-runtime --no-deps\` to /tmp
- \`unzip\` \`_runtime_modules.json\` from the wheel
- Merge \`top_level_modules\` + \`subpackages\` into the regex alternation (subpackages can be bare-imported too — e.g. \`from lib.pre_stop\`)
- On any fetch failure, fall back to the inline list with a workflow warning so the lint still runs

## Side benefit
The merged top_level + subpackage list catches a strictly larger class of bugs than before. The original inline list had only top-level modules; subpackage bare imports (like \`from lib.pre_stop import\` which bit hermes earlier today) would slip through. The new lint catches them.

## Dependency
Requires molecule-ai-workspace-runtime ≥ the version that ships \`_runtime_modules.json\` (see Molecule-AI/molecule-core#2174). Until that version cascades to PyPI, the fallback list is used — same behavior as before.

## Test plan
- [x] YAML validates
- [x] Manual: ran the manifest read against a locally-built wheel with the new file — produces the expected pipe-separated alt regex
- [ ] CI green
- [ ] After Molecule-AI/molecule-core#2174 lands + 0.1.20 publishes: next template publish-image run should log \"lint module list pulled from … manifest\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)