### PR TITLE
feat(reusable): disable auto-merge when a new commit is pushed

### DIFF
--- a/.github/workflows/disable-auto-merge-on-push.yml
+++ b/.github/workflows/disable-auto-merge-on-push.yml
@@ -1,0 +1,53 @@
+name: Disable auto-merge on push
+
+# Reusable guard against the "I enabled auto-merge then pushed more
+# commits" race. Background: on 2026-04-27, PR #2174 in molecule-core
+# auto-merged with only the first commit because the second commit
+# was pushed AFTER the merge queue had already locked the PR's SHA.
+# The second commit ended up orphaned on a merged-and-deleted branch.
+#
+# Mechanism: on every `pull_request: synchronize` event (= new commit
+# pushed to an open PR), check if auto-merge is enabled. If yes,
+# disable it and post a comment. This forces the operator to
+# re-engage `gh pr merge --auto` after the new push, with the
+# re-engagement acting as the verification step.
+#
+# Call from each repo's .github/workflows/ via a thin wrapper:
+#
+#   name: pr-guards
+#   on:
+#     pull_request:
+#       types: [synchronize]
+#   permissions:
+#     pull-requests: write
+#   jobs:
+#     disable-auto-merge-on-push:
+#       uses: Molecule-AI/molecule-ci/.github/workflows/disable-auto-merge-on-push.yml@main
+#
+# False-positive behavior: if a CI bot pushes (e.g. dependency-update
+# rebase, secret rotation), this also disables auto-merge for that
+# PR. That's acceptable — the operator who originally enabled
+# auto-merge gets notified and re-engages, which is exactly the
+# verify-after-machine-edits behavior we want.
+
+on:
+  workflow_call:
+
+jobs:
+  guard:
+    name: Disable auto-merge on push
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.auto_merge != null
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Disable auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          NEW_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          gh pr merge "$PR" --disable-auto -R "$REPO" || true
+          gh pr comment "$PR" -R "$REPO" --body "🔒 Auto-merge disabled — new commit (\`${NEW_SHA:0:7}\`) pushed after auto-merge was enabled. The merge queue locks SHAs at entry, so subsequent pushes can race. Verify the new commit and re-enable with \`gh pr merge --auto\`."


### PR DESCRIPTION
## Summary
Reusable workflow that consumers call from their \`pr-guards.yml\` on \`pull_request:synchronize\`. When a new commit is pushed to an open PR with auto-merge enabled, this disables auto-merge and posts a comment so the operator must explicitly re-engage.

## Why
2026-04-27 saw PR #2174 in molecule-core auto-merge with only the first commit because the second was pushed AFTER the queue had locked the SHA. The second commit ended up orphaned on a merged-and-deleted branch.

**Pairs with the org-wide "Automatically delete head branches" setting (already enabled on all 10 repos).** Defense in depth:
1. Repo setting blocks pushes to a merged branch (post-merge orphan case)
2. This workflow catches in-queue races (push during queue processing) by force-disabling auto-merge

Together: the full lifecycle of "auto-merge enabled → new commits arrive" is system-enforced, no operator discipline.

## Caller pattern
~5 lines per consuming repo:
\`\`\`yaml
name: pr-guards
on:
  pull_request:
    types: [synchronize]
permissions:
  pull-requests: write
jobs:
  disable-auto-merge-on-push:
    uses: Molecule-AI/molecule-ci/.github/workflows/disable-auto-merge-on-push.yml@main
\`\`\`

## Test plan
- [x] YAML validates
- [ ] CI green
- [ ] After merge: add the thin caller to molecule-core (highest-traffic repo). Test by enabling auto-merge on a draft PR and pushing a no-op commit — workflow should disable auto-merge + comment within ~30s
- [ ] Roll out to template repos in a follow-up sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)