### PR TITLE
docs: add disable-auto-merge-on-push to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ jobs:
     uses: Molecule-AI/molecule-ci/.github/workflows/validate-org-template.yml@main
 ```
 
+### Any repo with auto-merge enabled
+
+PR-time guards (currently: disable auto-merge on follow-up push). Consume from a thin caller:
+
+```yaml
+# .github/workflows/pr-guards.yml
+name: pr-guards
+on:
+  pull_request:
+    types: [synchronize]
+permissions:
+  pull-requests: write
+jobs:
+  disable-auto-merge-on-push:
+    uses: Molecule-AI/molecule-ci/.github/workflows/disable-auto-merge-on-push.yml@main
+```
+
+When the team lands more PR-time guards in this repo, add them as additional jobs in the same caller — keeps each consuming repo's footprint to one file.
+
 ## What each workflow validates
 
 ### validate-plugin
@@ -73,6 +92,21 @@ jobs:
 | `files_dir` references exist | Warning | Broken system-prompt paths |
 | `template_schema_version` present | Warning | Missing version contract |
 | No committed secrets | Error | Leaked API keys |
+
+### disable-auto-merge-on-push
+
+PR-time safety guard. When `pull_request:synchronize` fires (= a new commit pushed to an open PR) and auto-merge is already enabled, this workflow disables auto-merge and posts a comment requiring the operator to re-engage explicitly.
+
+**Why it exists:** on 2026-04-27, molecule-core PR #2174 auto-merged with only its first commit because the second commit was pushed AFTER the merge queue had locked the PR's SHA. The second commit ended up orphaned on a merged-and-deleted branch.
+
+**Pairs with the org-wide repo setting** "Automatically delete head branches" (already enabled on all 10 Molecule-AI repos). Defense in depth:
+
+1. Repo setting blocks pushes to a merged-and-deleted branch (catches the post-merge orphan case).
+2. This workflow catches the in-queue race (push during queue processing) by force-disabling auto-merge.
+
+Together they cover the full lifecycle of "auto-merge enabled → new commits arrive" without operator discipline.
+
+**False-positive note:** if a CI bot pushes (dependency update, secret rotation), this also disables auto-merge. That's intentional — the operator who originally enabled auto-merge gets notified and re-engages, which is exactly the verify-after-machine-edits behavior we want.
 
 ## License
 


### PR DESCRIPTION
Documents the reusable workflow from PR #10 — caller pattern + full description in the validators table. Companion to molecule-core PR #2177 (CONTRIBUTING.md). 🤖 Generated with Claude Code