### PR TITLE
feat(reusable): forward runtime_version as RUNTIME_VERSION build-arg

### DIFF
--- a/.github/workflows/publish-template-image.yml
+++ b/.github/workflows/publish-template-image.yml
@@ -40,6 +40,19 @@ on:
         required: false
         type: string
         default: ""
+      runtime_version:
+        description: >-
+          molecule-ai-workspace-runtime version to install. Forwarded
+          as RUNTIME_VERSION docker build-arg. When unset, the
+          Dockerfile's requirements.txt pin is used. Cascade-triggered
+          builds forward client_payload.runtime_version here so each
+          rebuild has a unique build-arg → unique cache key →
+          guaranteed fresh `pip install`. Solves the
+          "cascade rebuilt but image still has old runtime" cache
+          trap that bit us repeatedly on 2026-04-27.
+        required: false
+        type: string
+        default: ""
     outputs:
       image:
         description: "Full image reference that was pushed (with :latest tag)"
@@ -177,6 +190,14 @@ jobs:
           tags: ${{ steps.tags.outputs.image }}:sha-${{ steps.tags.outputs.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # RUNTIME_VERSION is empty by default. When the cascade fires
+          # (or workflow_dispatch is invoked with a version), it's the
+          # exact runtime version about to be installed. Forwarded as a
+          # build-arg so Dockerfiles that declare `ARG RUNTIME_VERSION`
+          # get cache-key invalidation per-version. Templates that
+          # don't declare the ARG silently ignore it (no breakage).
+          build-args: |
+            RUNTIME_VERSION=${{ inputs.runtime_version }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -221,7 +242,8 @@ jobs:
       - name: Push image to GHCR (post-smoke)
         # Now that the smoke test passed, push both tags. build-push-action
         # reuses the cached build from the load step above, so this is fast
-        # — it's effectively a layer push, not a rebuild.
+        # — it's effectively a layer push, not a rebuild. Same build-args
+        # passed for cache key consistency.
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -233,6 +255,8 @@ jobs:
             ${{ steps.tags.outputs.image }}:sha-${{ steps.tags.outputs.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            RUNTIME_VERSION=${{ inputs.runtime_version }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
Closes the cache trap that bit us 5x today. Reusable workflow now accepts `runtime_version` input and forwards as `--build-arg RUNTIME_VERSION=` to docker build. Templates declaring `ARG RUNTIME_VERSION` get per-version cache-key invalidation; templates that don't declare ignore silently (phased rollout safe).

Pairs with [Molecule-AI/molecule-core#2181](https://github.com/Molecule-AI/molecule-core/pull/2181) (PyPI propagation wait + path filter expansion). Together = no race, no stale cache.

🤖 Generated with Claude Code