### PR TITLE
docs: recommend @v1 over @main in reusable-workflow adoption snippets

### DIFF
--- a/.github/workflows/auto-promote-branch.yml
+++ b/.github/workflows/auto-promote-branch.yml
@@ -21,13 +21,21 @@ name: Auto-promote branch (reusable)
 #     administration: read     # read branch protection (REQUIRED — see below)
 #   jobs:
 #     promote:
-#       uses: Molecule-AI/molecule-ci/.github/workflows/auto-promote-branch.yml@main
+#       uses: Molecule-AI/molecule-ci/.github/workflows/auto-promote-branch.yml@v1
 #       with:
 #         from-branch: staging
 #         to-branch: main
 #
 # Repo-agnostic by design — gates are read from the consuming repo's
 # branch protection at run time, not hardcoded here.
+#
+# `@v1` is a moving tag pointing at the latest 1.x release of
+# molecule-ci's reusable workflows (GitHub Actions convention, same
+# as `actions/checkout@v4`). Breaking changes get a new `@v2` tag
+# and the old `@v1` keeps working for existing consumers. Pinning to
+# `@main` is also accepted for forward-compat preview but is
+# unstable — any change merged here rolls out instantly to consumers
+# without a release boundary.
 #
 # `administration: read` is REQUIRED. Without it, the branch-protection
 # API returns 403 and the workflow refuses to fast-forward (fail-loud),

--- a/.github/workflows/auto-promote-staging.yml
+++ b/.github/workflows/auto-promote-staging.yml
@@ -4,7 +4,7 @@ name: Auto-promote staging → main
 # `auto-promote-branch.yml` workflow factored out for org-wide reuse.
 # Other repos consume the same reusable workflow via:
 #
-#   uses: Molecule-AI/molecule-ci/.github/workflows/auto-promote-branch.yml@main
+#   uses: Molecule-AI/molecule-ci/.github/workflows/auto-promote-branch.yml@v1
 #
 # Excluded by policy: molecule-core + molecule-controlplane stay
 # manual per CEO directive 2026-04-24. Those repos do NOT call the

--- a/.github/workflows/disable-auto-merge-on-push.yml
+++ b/.github/workflows/disable-auto-merge-on-push.yml
@@ -22,7 +22,7 @@ name: Disable auto-merge on push
 #     pull-requests: write
 #   jobs:
 #     disable-auto-merge-on-push:
-#       uses: Molecule-AI/molecule-ci/.github/workflows/disable-auto-merge-on-push.yml@main
+#       uses: Molecule-AI/molecule-ci/.github/workflows/disable-auto-merge-on-push.yml@v1
 #
 # False-positive behavior: if a CI bot pushes (e.g. dependency-update
 # rebase, secret rotation), this also disables auto-merge for that

--- a/.github/workflows/publish-template-image.yml
+++ b/.github/workflows/publish-template-image.yml
@@ -17,7 +17,7 @@ name: Publish Workspace Template Image
 #     packages: write
 #   jobs:
 #     publish:
-#       uses: Molecule-AI/molecule-ci/.github/workflows/publish-template-image.yml@main
+#       uses: Molecule-AI/molecule-ci/.github/workflows/publish-template-image.yml@v1
 #       secrets: inherit
 #
 # Runner choice (2026-04-22): ubuntu-latest


### PR DESCRIPTION
## Summary

Closes the README half of [monorepo task #133](https://github.com/Molecule-AI/molecule-core/issues/). The `v1` git tag now exists at the current `main` HEAD (after PR #15 landed). This PR updates example adoption snippets in 4 reusable-workflow headers to recommend `@v1` so new consumers get a stable pin from day one.

## What changed

| File | Change |
|---|---|
| `auto-promote-branch.yml` | snippet `@main` → `@v1`; added a paragraph explaining the `@v1` vs `@main` convention |
| `auto-promote-staging.yml` | snippet `@main` → `@v1` (the inline example referencing auto-promote-branch.yml) |
| `disable-auto-merge-on-push.yml` | snippet `@main` → `@v1` |
| `publish-template-image.yml` | snippet `@main` → `@v1` |

## What did NOT change

- Existing consumers pinned at `@main` keep working — the workflow content is identical, this only updates the example.
- The validate-* workflows (validate-plugin / validate-org-template / validate-workspace-template) don't have adoption snippets in their headers; adding canonical examples there is separate scope.
- The `v1` tag itself was already pushed to point at main HEAD (8b0fbac).

## Verification

All 4 workflow YAMLs parse. No `@main` references remain in adoption snippets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)