### PR TITLE
feat(ci): add validate-go-plugin reusable workflow

### DIFF
--- a/.github/workflows/validate-go-plugin.yml
+++ b/.github/workflows/validate-go-plugin.yml
@@ -1,0 +1,131 @@
+name: Validate Go Plugin
+
+# Reusable workflow for Go-binary plugins in the Molecule org.
+#
+# Counterpart to validate-plugin.yml which is skill/prompt-shaped
+# (expects plugin.yaml + SKILL.md/hooks/skills/) and doesn't fit
+# Go binaries. Without this workflow each Go plugin had to copy the
+# same go-build/vet/test loop into its own ci.yml — drift was
+# guaranteed (e.g. one plugin shipped without `go mod tidy` diff
+# verification, another without `gofmt -l`). This is the canonical
+# floor; consumers add plugin-specific extras (e.g. shellcheck for
+# the wrapper scripts in gh-identity) on top.
+#
+# Consumer pattern (3-line per-plugin ci.yml):
+#
+#   jobs:
+#     secret-scan:
+#       uses: Molecule-AI/molecule-core/.github/workflows/secret-scan.yml@staging
+#     validate-go:
+#       uses: Molecule-AI/molecule-ci/.github/workflows/validate-go-plugin.yml@staging
+#
+# Inputs let plugins with non-standard package layouts opt in:
+#
+#   github-app-auth's cmd/ + pluginloader/ packages require the
+#   molecule-core platform module to compile (provisionhook.Registry
+#   is in molecule-core). Tests only target ./internal/... — the
+#   plugin's self-contained business logic. Pin via:
+#
+#     validate-go:
+#       uses: Molecule-AI/molecule-ci/.github/workflows/validate-go-plugin.yml@staging
+#       with:
+#         packages: ./internal/...
+#
+# Pin to @staging not @main — staging is the active default for
+# molecule-core's reusable workflows; main lags via the promotion
+# workflow. Keeps consumer workflows in lockstep with the canonical
+# secret-scan @staging pin documented in molecule-core/secret-scan.yml.
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: "Go toolchain version. 1.25 is the org default."
+        type: string
+        required: false
+        default: "1.25"
+      packages:
+        description: "Go package selector for build/vet/test. Default ./... covers the whole module; override for plugins whose cmd/ requires external modules to compile."
+        type: string
+        required: false
+        default: "./..."
+
+jobs:
+  build-vet-test:
+    name: Go build, vet, test (-race)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      # Pin go.mod + go.sum stability. Without this an unstable
+      # module graph (newly-added import that wasn't tidied) would
+      # only surface on the next consumer's CI — drift across PRs.
+      - name: go mod tidy (verify clean)
+        run: |
+          go mod tidy
+          if ! git diff --exit-code go.mod go.sum; then
+            echo "::error::go.mod/go.sum drift detected. Run 'go mod tidy' locally and commit."
+            exit 1
+          fi
+
+      - name: go build
+        run: go build ${{ inputs.packages }}
+
+      - name: go vet
+        run: go vet ${{ inputs.packages }}
+
+      # -race catches concurrency issues that aren't visible to vet.
+      # -count=1 disables the test cache so the gate is honest about
+      # what this commit actually exercises.
+      - name: go test (-race)
+        run: go test -race -count=1 ${{ inputs.packages }}
+
+  gofmt:
+    name: gofmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      # gofmt -l prints unformatted files; failing on non-empty
+      # output keeps the canonical formatting floor without needing
+      # a third-party action.
+      - name: gofmt -l
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::Unformatted Go files (run 'gofmt -w'):"
+            echo "$unformatted"
+            exit 1
+          fi
+
+  govulncheck:
+    name: govulncheck (Go CVE scan)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      # govulncheck reports known CVEs in transitive deps that the
+      # plugin's compiled binary actually reaches (it uses call-graph
+      # analysis, not just go.sum scanning, so the false-positive
+      # rate stays low). Fails CI on any reachable advisory; opt-out
+      # is to upgrade the dep, not silence the gate.
+      - name: govulncheck install
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: govulncheck run
+        run: govulncheck ${{ inputs.packages }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Shared CI workflows for the Molecule AI ecosystem. Every plugin, workspace templ
 
 ### Plugin repos (`molecule-ai-plugin-*`)
 
+Skill/prompt-shaped plugins (the majority — Python with `plugin.yaml` + `SKILL.md`/`hooks`/`skills`/`rules`):
+
 ```yaml
 # .github/workflows/ci.yml
 name: CI
@@ -13,6 +15,21 @@ on: [push, pull_request]
 jobs:
   validate:
     uses: Molecule-AI/molecule-ci/.github/workflows/validate-plugin.yml@main
+```
+
+Go-binary plugins (compiled `provisionhook.Registry` registrants — `molecule-ai-plugin-gh-identity`, `molecule-ai-plugin-github-app-auth`):
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+on: [push, pull_request]
+jobs:
+  secret-scan:
+    uses: Molecule-AI/molecule-core/.github/workflows/secret-scan.yml@staging
+  validate-go:
+    uses: Molecule-AI/molecule-ci/.github/workflows/validate-go-plugin.yml@staging
+    # with:
+    #   packages: ./internal/...   # narrower test scope when cmd/ requires external modules
 ```
 
 ### Workspace template repos (`molecule-ai-workspace-template-*`)
@@ -49,6 +66,21 @@ jobs:
 | SKILL.md starts with heading | Warning | Bad formatting |
 | No committed secrets | Error | Leaked API keys |
 | No build artifacts | Error | node_modules, __pycache__ |
+
+### validate-go-plugin
+
+| Check | Severity | What it catches |
+|---|---|---|
+| `go mod tidy` clean | Error | Drifting go.mod/go.sum |
+| `go build` | Error | Broken compile |
+| `go vet` | Error | Suspicious constructs |
+| `go test -race -count=1` | Error | Concurrency bugs + cache lies |
+| `gofmt -l` | Error | Unformatted files |
+| `govulncheck` | Error | Reachable CVEs in deps |
+
+Inputs:
+- `go-version` (default `"1.25"`)
+- `packages` (default `"./..."`) — pin narrower for plugins whose top-level cmd packages require external modules
 
 ### validate-workspace-template
 


### PR DESCRIPTION
## Summary

Adds \`validate-go-plugin.yml\` reusable workflow as the canonical Go-plugin CI floor for the org. Counterpart to \`validate-plugin.yml\` (skill/prompt-shaped plugins).

## Why

The two Go plugins in the org (\`molecule-ai-plugin-gh-identity\`, \`molecule-ai-plugin-github-app-auth\`) couldn't enroll in \`validate-plugin.yml\` because that workflow expects \`plugin.yaml\` + \`SKILL.md\`/\`hooks\`/\`skills\`/\`rules\` — none of which apply to compiled \`provisionhook.Registry\` registrants. Each currently carries its own inline ci.yml with \`go build\`/\`vet\`/\`test\`, drifting independently (one has \`go mod tidy\` diff verification, the other doesn't; neither has \`gofmt -l\` or \`govulncheck\`). This is the gap behind task #94.

Refactoring the inline jobs into a reusable workflow means: one place to bump Go versions, one place to add new gates (govulncheck, gosec later), no copy-paste drift when a third Go plugin shows up.

## Gates included

| Gate | Catches |
|---|---|
| \`go mod tidy\` clean | Drifting go.mod/go.sum |
| \`go build\` | Broken compile |
| \`go vet\` | Suspicious constructs |
| \`go test -race -count=1\` | Concurrency bugs + test-cache lies |
| \`gofmt -l\` | Unformatted files |
| \`govulncheck\` | Reachable CVEs in deps |

Inputs:
- \`go-version\` (default \`\"1.25\"\`)
- \`packages\` (default \`\"./...\"\`) — narrower scope for plugins whose top-level \`cmd/\` packages require external modules to compile (e.g. \`github-app-auth\` uses \`./internal/...\`).

## Out of scope (intentionally)

- Secret-scan stays a sibling job in each plugin's ci.yml, calling \`molecule-core/secret-scan.yml@staging\` directly. Two top-level \`uses:\` blocks beat one nested workflow_call chain — and the secret-scan canonical lives in molecule-core anyway, not here.
- Plugin signing / provenance — separate task #92.

## Follow-ups (after this lands on staging)

- PR \`molecule-ai-plugin-gh-identity\` to switch inline go job → \`uses: validate-go-plugin.yml@staging\`
- PR \`molecule-ai-plugin-github-app-auth\` to switch inline go job → \`uses: validate-go-plugin.yml@staging\` with \`packages: ./internal/...\`

## Test plan

- [x] YAML lints clean (no syntax issues)
- [ ] Once merged: open consumer PRs for each plugin and verify the workflow runs green end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)