### PR TITLE
fix(validate-go-plugin): add skip-mod-tidy input for plugins with relative replace

### DIFF
--- a/.github/workflows/validate-go-plugin.yml
+++ b/.github/workflows/validate-go-plugin.yml
@@ -49,6 +49,11 @@ on:
         type: string
         required: false
         default: "./..."
+      skip-mod-tidy:
+        description: "Skip the `go mod tidy` cleanliness gate. Set true for plugins whose go.mod uses a relative replace directive (e.g. ../molecule-monorepo/platform) that is unresolvable in CI — go mod tidy traverses every replace target and errors when the path doesn't exist. Default false."
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build-vet-test:
@@ -65,7 +70,17 @@ jobs:
       # Pin go.mod + go.sum stability. Without this an unstable
       # module graph (newly-added import that wasn't tidied) would
       # only surface on the next consumer's CI — drift across PRs.
+      #
+      # skip-mod-tidy: opt-out for plugins whose go.mod has a
+      # relative `replace` directive (e.g. github-app-auth replaces
+      # molecule-monorepo with ../molecule-monorepo/platform).
+      # `go mod tidy` traverses every replace target and fails when
+      # the path isn't reachable — there's nothing the gate can do
+      # about that without unwiring the plugin's external-checkout
+      # dev workflow. The gate is preserved for the common case;
+      # opt-outs are noisy on purpose so a future fix is visible.
       - name: go mod tidy (verify clean)
+        if: ${{ !inputs.skip-mod-tidy }}
         run: |
           go mod tidy
           if ! git diff --exit-code go.mod go.sum; then

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ jobs:
 Inputs:
 - `go-version` (default `"1.25"`)
 - `packages` (default `"./..."`) — pin narrower for plugins whose top-level cmd packages require external modules
+- `skip-mod-tidy` (default `false`) — opt-out for plugins whose `go.mod` uses a relative `replace` directive (e.g. `../molecule-monorepo/platform`); `go mod tidy` traverses every replace target and fails when the path doesn't exist in CI
 
 ### validate-workspace-template
 


### PR DESCRIPTION
## Summary

Adds \`skip-mod-tidy\` boolean input to the \`validate-go-plugin\` reusable workflow. Default \`false\` (gate stays on for the common case).

## Why

\`molecule-ai-plugin-github-app-auth\` has \`go.mod\`:

\`\`\`go
replace github.com/Molecule-AI/molecule-monorepo/platform => ../molecule-monorepo/platform
\`\`\`

Operators set \`replace\` back to their local platform checkout for development. In CI the path doesn't exist, so \`go mod tidy\` errors out before the gate's diff check ever runs:

\`\`\`
go: ../pluginloader imports github.com/.../provisionhook:
    replacement directory ../molecule-monorepo/platform does not exist
\`\`\`

Without \`skip-mod-tidy\` that plugin can never enroll in the canonical workflow. Build/vet/test against \`./internal/...\` work fine because \`internal/githubapp\` is self-contained — it's just \`go mod tidy\` that traverses every replace target.

## Behavior

- \`skip-mod-tidy: false\` (default) — unchanged, runs \`go mod tidy\` + diff check.
- \`skip-mod-tidy: true\` — skips the tidy gate; build/vet/test/gofmt/govulncheck stay active.

## Test plan

- [ ] CI green on this PR
- [ ] Once merged: github-app-auth #6 passes once it pins \`skip-mod-tidy: true\` (separate follow-up commit on that PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)