### PR TITLE
fix(validate): fetch scripts from molecule-ci instead of vendored copy

### DIFF
--- a/.github/workflows/validate-org-template.yml
+++ b/.github/workflows/validate-org-template.yml
@@ -9,13 +9,23 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+      # Canonical validator script lives in molecule-ci, fetched fresh on
+      # every run. The previous setup expected `.molecule-ci/scripts/` to
+      # be vendored INTO each org-template repo, which drifted across the
+      # 5 org-template repos as the validator evolved. Single source of
+      # truth eliminates that drift class entirely. Mirrors the same
+      # pattern already used by validate-workspace-template.yml.
+      - uses: actions/checkout@v4
+        with:
+          repository: Molecule-AI/molecule-ci
+          path: .molecule-ci-canonical
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: "pip"
-          cache-dependency-path: .molecule-ci/scripts/requirements.txt
+          cache-dependency-path: .molecule-ci-canonical/.molecule-ci/scripts/requirements.txt
       - run: pip install pyyaml -q
-      - run: python3 .molecule-ci/scripts/validate-org-template.py
+      - run: python3 .molecule-ci-canonical/.molecule-ci/scripts/validate-org-template.py
       - name: Check for secrets
         run: |
           python3 - << 'PYEOF'
@@ -32,7 +42,7 @@ jobs:
               re.compile(r'''ghp_[a-zA-Z0-9]{36,}'''),
               re.compile(r'''sk-ant-[a-zA-Z0-9]{50,}'''),
           ]
-          SKIP_DIRS = {'.molecule-ci', '.git', 'node_modules', '__pycache__'}
+          SKIP_DIRS = {'.molecule-ci', '.molecule-ci-canonical', '.git', 'node_modules', '__pycache__'}
           EXTENSIONS = {'.yaml', '.yml', '.md', '.py', '.sh'}
 
           def is_false_positive(line):

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -9,13 +9,23 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+      # Canonical validator script lives in molecule-ci, fetched fresh on
+      # every run. The previous setup expected `.molecule-ci/scripts/` to
+      # be vendored INTO each plugin repo, which drifted across the
+      # 20+ plugin repos as the validator evolved. Single source of
+      # truth eliminates that drift class entirely. Mirrors the same
+      # pattern already used by validate-workspace-template.yml.
+      - uses: actions/checkout@v4
+        with:
+          repository: Molecule-AI/molecule-ci
+          path: .molecule-ci-canonical
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: "pip"
-          cache-dependency-path: .molecule-ci/scripts/requirements.txt
+          cache-dependency-path: .molecule-ci-canonical/.molecule-ci/scripts/requirements.txt
       - run: pip install pyyaml -q
-      - run: python3 .molecule-ci/scripts/validate-plugin.py
+      - run: python3 .molecule-ci-canonical/.molecule-ci/scripts/validate-plugin.py
       - name: Check for secrets
         run: |
           python3 - << 'PYEOF'
@@ -32,7 +42,7 @@ jobs:
               re.compile(r'''ghp_[a-zA-Z0-9]{36,}'''),
               re.compile(r'''sk-ant-[a-zA-Z0-9]{50,}'''),
           ]
-          SKIP_DIRS = {'.molecule-ci', '.git', 'node_modules', '__pycache__'}
+          SKIP_DIRS = {'.molecule-ci', '.molecule-ci-canonical', '.git', 'node_modules', '__pycache__'}
           EXTENSIONS = {'.yaml', '.yml', '.md', '.py', '.sh'}
 
           def is_false_positive(line):


### PR DESCRIPTION
## Summary

\`validate-org-template.yml\` and \`validate-plugin.yml\` expected \`.molecule-ci/scripts/\` to be vendored into the calling repo. That broke when callers didn't have the directory.

This PR: mirror the fix already in \`validate-workspace-template.yml\` — a second \`actions/checkout@v4\` of molecule-ci into \`.molecule-ci-canonical/\`, re-point script paths.

## Currently broken (will be fixed by this PR)

- \`molecule-ai-org-template-medo-smoke#2\`
- \`molecule-ai-org-template-molecule-worker-gemini#2\`
- \`molecule-ai-org-template-reno-stars#2\`
- \`molecule-ai-plugin-molecule-compliance#2\`
- \`molecule-ai-plugin-molecule-freeze-scope#2\`
- \`molecule-ai-plugin-molecule-prompt-watchdog#2\`

All 6 are stuck on \`validate / Org template validation\` (or \`/ Plugin validation\`) failing with: \`No file in [...] matched to [.molecule-ci/scripts/requirements.txt or **/pyproject.toml]\`.

## Changes

- Add a second checkout of molecule-ci into \`.molecule-ci-canonical/\` in both workflows.
- Re-point \`cache-dependency-path\` and \`python3 ...\` invocations.
- Add \`.molecule-ci-canonical\` to secret-scan \`SKIP_DIRS\` so the side-tree isn't walked.
- Backwards compatible: callers that still have a vendored \`.molecule-ci/scripts/\` copy are unaffected — the workflow no longer reads from there, so the vendored copy becomes harmless dead weight (cleanup deferred to a separate PR).

## Verification

- [x] \`yaml.safe_load\` parses both workflows
- [ ] After merge: re-trigger CI on the 6 stuck PRs and confirm validate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)