### PR TITLE
docs: pin reusable-workflow examples from @main to @v1 (P133)

### DIFF
--- a/.github/workflows/auto-promote-staging-pr.yml
+++ b/.github/workflows/auto-promote-staging-pr.yml
@@ -28,7 +28,7 @@ name: Auto-promote staging → main (PR-based, reusable)
 #     pull-requests: write
 #   jobs:
 #     promote:
-#       uses: Molecule-AI/molecule-ci/.github/workflows/auto-promote-staging-pr.yml@main
+#       uses: Molecule-AI/molecule-ci/.github/workflows/auto-promote-staging-pr.yml@v1
 #       with:
 #         gates: "ci.yml,e2e-staging-canvas.yml,e2e-api.yml,codeql.yml"
 #         force: ${{ github.event.inputs.force == 'true' }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   validate:
-    uses: Molecule-AI/molecule-ci/.github/workflows/validate-plugin.yml@main
+    uses: Molecule-AI/molecule-ci/.github/workflows/validate-plugin.yml@v1
 ```
 
 ### Workspace template repos (`molecule-ai-workspace-template-*`)
@@ -23,7 +23,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   validate:
-    uses: Molecule-AI/molecule-ci/.github/workflows/validate-workspace-template.yml@main
+    uses: Molecule-AI/molecule-ci/.github/workflows/validate-workspace-template.yml@v1
 ```
 
 ### Org template repos (`molecule-ai-org-template-*`)
@@ -34,7 +34,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   validate:
-    uses: Molecule-AI/molecule-ci/.github/workflows/validate-org-template.yml@main
+    uses: Molecule-AI/molecule-ci/.github/workflows/validate-org-template.yml@v1
 ```
 
 ### Any repo with auto-merge enabled
@@ -51,7 +51,7 @@ permissions:
   pull-requests: write
 jobs:
   disable-auto-merge-on-push:
-    uses: Molecule-AI/molecule-ci/.github/workflows/disable-auto-merge-on-push.yml@main
+    uses: Molecule-AI/molecule-ci/.github/workflows/disable-auto-merge-on-push.yml@v1
 ```
 
 When the team lands more PR-time guards in this repo, add them as additional jobs in the same caller — keeps each consuming repo's footprint to one file.

--- a/docs/template-contract.md
+++ b/docs/template-contract.md
@@ -54,7 +54,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   validate:
-    uses: Molecule-AI/molecule-ci/.github/workflows/validate-workspace-template.yml@main
+    uses: Molecule-AI/molecule-ci/.github/workflows/validate-workspace-template.yml@v1
 ```
 
 The reusable workflow checks out `molecule-ci` itself (into `.molecule-ci-canonical`) and runs the canonical `validate-workspace-template.py` from there — so no per-repo vendoring of the script is needed. The legacy `.molecule-ci/scripts/` directory in each template repo is being phased out.


### PR DESCRIPTION
**Closes task #133.** v1 tag exists in this repo but README + docs still showed \`@main\` in the caller-pattern examples — followers of the docs were copy-pasting unstable \`@main\` pins.

Fix: update all 6 example references to \`@v1\`:

- \`README.md\` — 4 examples (validate-plugin, validate-workspace-template, validate-org-template, disable-auto-merge-on-push)
- \`docs/template-contract.md\` — 1 example (validate-workspace-template)
- \`.github/workflows/auto-promote-staging-pr.yml\` header comment — 1 example (the new reusable from PR #25)

## Operational note

v1 is meant to track the latest stable patch within the v1 major. Cutting a new v1.X.Y or breaking-change v2 requires moving the v1 tag forward — same convention as \`actions/checkout@v4\` etc.

## What's NOT in this PR

Doesn't migrate any consumer repo. Consumer migration from \`@main\` to \`@v1\` is a per-repo follow-up; this PR ships the docs that guide that migration.

## Test plan
- [x] All 6 references replaced (verified via grep)
- [x] YAML parses
- [ ] CI green