### PR TITLE
feat(publish-template-image): add execute()-against-stub-deps boot smoke (#2275)

### DIFF
--- a/.github/workflows/publish-template-image.yml
+++ b/.github/workflows/publish-template-image.yml
@@ -239,6 +239,89 @@ jobs:
           '
           echo "::notice::✓ ${IMAGE} all /app/*.py modules import cleanly against installed runtime"
 
+      - name: Boot smoke — execute() against stub deps (#2275)
+        # The static import smoke above only IMPORTs /app/*.py — lazy
+        # imports buried inside `async def execute(...)` bodies (e.g.
+        # `from a2a.types import FilePart`) NEVER evaluate at static-
+        # import time. The 2026-04-2x v0→v1 a2a-sdk migration shipped 5
+        # such regressions in templates that all looked fine at module-
+        # load smoke (claude-code, langgraph, deepagents, gemini-cli,
+        # hermes — every one a separate provisioning incident).
+        #
+        # This step boots the image with MOLECULE_SMOKE_MODE=1, which
+        # routes molecule-runtime through smoke_mode.run_executor_smoke()
+        # — invokes executor.execute(stub_ctx, stub_queue) once with a
+        # short timeout. Healthy import tree → execution proceeds far
+        # enough to hit a network boundary and times out (exit 0).
+        # Broken lazy import → ImportError/ModuleNotFoundError from
+        # inside the executor body (exit 1).
+        #
+        # Requires runtime >= 0.1.60 (the version that introduced
+        # smoke_mode). Older runtimes silently no-op and would hang on
+        # uvicorn, so we detect the module first and skip if absent —
+        # this lets templates pinned to older runtimes continue to
+        # publish without this gate flipping red, while every fresh
+        # cascade-triggered build (which forwards the just-published
+        # version as RUNTIME_VERSION) gets the gate automatically.
+        #
+        # Wrapped in `timeout` as a belt-and-suspenders safety net in
+        # case smoke_mode itself wedges — runner shouldn't hang
+        # indefinitely on a single template.
+        shell: bash
+        env:
+          IMAGE: ${{ steps.tags.outputs.image }}:sha-${{ steps.tags.outputs.sha }}
+        run: |
+          set -eu
+
+          HAS_SMOKE_MODE=$(docker run --rm --entrypoint sh "${IMAGE}" -c \
+            'python3 -c "import molecule_runtime.smoke_mode" >/dev/null 2>&1 && echo yes || echo no')
+          if [ "${HAS_SMOKE_MODE}" = "no" ]; then
+            echo "::warning::installed runtime predates molecule-core#2275 (no molecule_runtime.smoke_mode); skipping boot smoke. Bump requirements.txt to molecule-ai-workspace-runtime>=0.1.60 to enable."
+            exit 0
+          fi
+
+          if [ ! -f config.yaml ]; then
+            echo "::error::config.yaml not found at repo root — boot smoke needs it to populate /configs. Templates without a config.yaml at root cannot be boot-smoked; either add one or skip this gate by setting an old runtime pin."
+            exit 1
+          fi
+
+          # Mount the repo's own config.yaml at /configs so the runtime
+          # can reach create_executor() — that's where the lazy imports
+          # we want to test actually live. World-readable so the
+          # entrypoint's drop-priv to uid 1000 can read it.
+          SMOKE_CONFIG_DIR=$(mktemp -d)
+          cp config.yaml "${SMOKE_CONFIG_DIR}/"
+          chmod -R go+r "${SMOKE_CONFIG_DIR}"
+
+          # Stub credentials — adapters validate shape at create_executor
+          # time but the smoke times out before any real call goes out.
+          # Set the common ones so any adapter that early-validates a
+          # specific key sees a non-empty value.
+          set +e
+          timeout 60 docker run --rm \
+            -v "${SMOKE_CONFIG_DIR}:/configs:ro" \
+            -e WORKSPACE_ID=fake-smoke \
+            -e MOLECULE_SMOKE_MODE=1 \
+            -e MOLECULE_SMOKE_TIMEOUT_SECS=10 \
+            -e CLAUDE_CODE_OAUTH_TOKEN=sk-fake-smoke-token \
+            -e ANTHROPIC_API_KEY=sk-fake-smoke-key \
+            -e GEMINI_API_KEY=fake-smoke-key \
+            -e OPENAI_API_KEY=sk-fake-smoke-key \
+            "${IMAGE}"
+          rc=$?
+          set -e
+          rm -rf "${SMOKE_CONFIG_DIR}"
+
+          if [ "${rc}" -eq 124 ]; then
+            echo "::error::boot smoke wedged past 60s — smoke_mode itself failed to terminate (look for blocking calls before MOLECULE_SMOKE_TIMEOUT_SECS fires)"
+            exit 1
+          fi
+          if [ "${rc}" -ne 0 ]; then
+            echo "::error::boot smoke failed (exit ${rc}) — executor.execute() raised an import error against the installed runtime. Check the container log above for the offending lazy import."
+            exit "${rc}"
+          fi
+          echo "::notice::✓ ${IMAGE} executor.execute() smoke passed (lazy imports healthy)"
+
       - name: Push image to GHCR (post-smoke)
         # Now that the smoke test passed, push both tags. build-push-action
         # reuses the cached build from the load step above, so this is fast


### PR DESCRIPTION
## Summary

Phase 2 of [molecule-core#2275](https://github.com/Molecule-AI/molecule-core/issues/2275). Phase 1 (the `smoke_mode.py` module + `MOLECULE_SMOKE_MODE=1` short-circuit in `main.py`) shipped to molecule-core staging in [PR #2446](https://github.com/Molecule-AI/molecule-core/pull/2446) and is on PyPI as `molecule-ai-workspace-runtime==0.1.60`.

This PR wires that gate into the publish workflow. Adds a step between the existing static import smoke and the GHCR push that boots the just-built image with `MOLECULE_SMOKE_MODE=1` — `executor.execute(stub_ctx, stub_queue)` runs once with a 10s timeout against the real installed wheel.

| Outcome | Exit | Verdict |
|---|---|---|
| Execution proceeds past imports, hits a network boundary, times out | 0 | Imports healthy ✓ |
| Execution returns cleanly within timeout | 0 | Imports + body OK ✓ |
| Lazy `ImportError`/`ModuleNotFoundError` from inside `execute()` | 1 | Gate blocks publish ✗ |
| Stub-context build fails (a2a-sdk SDK refactored) | 1 | Gate blocks publish ✗ |
| `timeout 60` fires (smoke_mode itself wedges) | 124 → 1 | Belt-and-suspenders ✗ |

## Why

The existing import smoke (`docker run --entrypoint sh ... python3 -c "import $mod"`) only IMPORTs `/app/*.py` at module scope. Lazy imports buried inside `async def execute(...)` bodies (e.g. `from a2a.types import FilePart`) NEVER evaluate at static-import time. The 2026-04-2x v0→v1 a2a-sdk migration shipped 5 such regressions in templates that all looked fine at module-load smoke (claude-code, langgraph, deepagents, gemini-cli, hermes — every one a separate provisioning incident).

## Backwards compat

Templates pinned to a runtime version older than 0.1.60 don't have `molecule_runtime.smoke_mode` available. The step detects that and skips with a `::warning::` instead of failing. Cascade-triggered rebuilds (which forward the just-published RUNTIME_VERSION as a build-arg) automatically pick up the gate the moment they install ≥0.1.60.

## Verification

- [x] Phase 1 wheel verified end-to-end against PyPI 0.1.60 with three executor shapes (FilePart-broken → 1, clean → 0, blocking → 0).
- [x] YAML syntax valid (`yaml.safe_load`).
- [ ] **After merge: bump `v1` tag to point at the new main SHA.** Caller repos (`molecule-ai-workspace-template-*`) pin to `@v1` — without the bump the workflow change has no effect.

## Test plan

- [x] Phase 1 wheel-level smoke (covered in #2446)
- [ ] First template publish after `v1` bump exercises the new step end-to-end
- [ ] Verify skip path on a template still pinned to <0.1.60 (warning shown, exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)