### PR TITLE
fix(publish-template-image): chmod a+rX + drop :ro so agent can read /configs

### DIFF
--- a/.github/workflows/publish-template-image.yml
+++ b/.github/workflows/publish-template-image.yml
@@ -287,11 +287,22 @@ jobs:
 
           # Mount the repo's own config.yaml at /configs so the runtime
           # can reach create_executor() — that's where the lazy imports
-          # we want to test actually live. World-readable so the
-          # entrypoint's drop-priv to uid 1000 can read it.
+          # we want to test actually live. The image's entrypoint drops
+          # priv from root to agent (uid 1000) before exec'ing
+          # molecule-runtime, so /configs needs to be readable AND
+          # traversable from uid 1000.
+          #
+          # Use `a+rX` (capital X — only adds x where it's already
+          # executable, i.e. directories): mktemp -d creates the dir
+          # with mode 700, so a bare `go+r` would leave the dir
+          # un-traversable for agent and config.py would
+          # PermissionError on `Path('/configs/config.yaml').exists()`.
+          # Mount RW (not :ro) so the entrypoint's `chown -R agent
+          # /configs` succeeds — its silent chown failure on a :ro
+          # mount was the original symptom.
           SMOKE_CONFIG_DIR=$(mktemp -d)
           cp config.yaml "${SMOKE_CONFIG_DIR}/"
-          chmod -R go+r "${SMOKE_CONFIG_DIR}"
+          chmod -R a+rX "${SMOKE_CONFIG_DIR}"
 
           # Stub credentials — adapters validate shape at create_executor
           # time but the smoke times out before any real call goes out.
@@ -299,7 +310,7 @@ jobs:
           # specific key sees a non-empty value.
           set +e
           timeout 60 docker run --rm \
-            -v "${SMOKE_CONFIG_DIR}:/configs:ro" \
+            -v "${SMOKE_CONFIG_DIR}:/configs" \
             -e WORKSPACE_ID=fake-smoke \
             -e MOLECULE_SMOKE_MODE=1 \
             -e MOLECULE_SMOKE_TIMEOUT_SECS=10 \


### PR DESCRIPTION
## Summary

Hot-fix for #2275 Phase 2 — every template publish since v1@3c8f8fe fails on the new boot smoke step with `PermissionError: [Errno 13] Permission denied: '/configs/config.yaml'`.

**Root cause:** \`mktemp -d\` creates the dir with mode 700. \`chmod -R go+r\` adds 'r' to files but **doesn't add 'x' to directories** — agent (uid 1000) inside the image can't traverse \`/configs\` to even reach \`config.yaml\`. main.py exits inside \`config.py:298 / Path.exists()\` before any executor code runs.

**Fix:**
1. \`chmod -R a+rX\` (capital X) adds 'x' to directories AND already-executable files. Temp dir becomes traversable; \`config.yaml\` stays a regular readable file.
2. Drop \`:ro\` on the mount so the entrypoint's \`chown -R agent /configs\` succeeds. Container is ephemeral; host mktemp dir gets removed right after the smoke run.

Reproduced + diagnosed against claude-code publish run [25202651546](https://github.com/Molecule-AI/molecule-ai-workspace-template-claude-code/actions/runs/25202651546).

## Test plan

- [x] YAML validates.
- [ ] After merge + v1 bump: re-run claude-code publish; expect boot smoke step to either timeout (exit 0, healthy imports) or surface a real lazy import (exit 1).