### PR TITLE
fix(publish-template-image): tolerate host-side uid 1000 ownership in smoke cleanup

### DIFF
--- a/.github/workflows/publish-template-image.yml
+++ b/.github/workflows/publish-template-image.yml
@@ -332,7 +332,15 @@ jobs:
             "${IMAGE}"
           rc=$?
           set -e
-          rm -rf "${SMOKE_CONFIG_DIR}"
+          # Cleanup is best-effort: the entrypoint chowns /configs to
+          # uid 1000 (agent) inside the container, which propagates to
+          # the host bind-mount, leaving the runner user unable to
+          # remove the files. Fall back to `sudo rm` and ignore any
+          # remaining failure — the runner is ephemeral, /tmp is
+          # cleaned automatically post-job.
+          rm -rf "${SMOKE_CONFIG_DIR}" 2>/dev/null \
+            || sudo rm -rf "${SMOKE_CONFIG_DIR}" 2>/dev/null \
+            || true
 
           if [ "${rc}" -eq 124 ]; then
             echo "::error::boot smoke wedged past 60s — smoke_mode itself failed to terminate (look for blocking calls before MOLECULE_SMOKE_TIMEOUT_SECS fires)"


### PR DESCRIPTION
Third hot-fix for #2275 Phase 2. Claude-code [run #25202859503](https://github.com/Molecule-AI/molecule-ai-workspace-template-claude-code/actions/runs/25202859503) showed the boot smoke ITSELF passing (`[smoke-mode] PASS: timed out past import-tree`) but the step still exited 1 because the post-smoke `rm -rf` couldn't delete files chown'd to uid 1000 by the entrypoint.

Best-effort cleanup with sudo fallback. Runner is ephemeral — /tmp gets cleaned at job teardown anyway.