### PR TITLE
ci: add Template validation aggregator (restore historical check name)

### DIFF
--- a/.github/workflows/validate-workspace-template.yml
+++ b/.github/workflows/validate-workspace-template.yml
@@ -164,3 +164,47 @@ jobs:
       - name: Docker build smoke test
         if: hashFiles('Dockerfile') != ''
         run: docker build -t template-test . --no-cache 2>&1 | tail -5 && echo "✓ Docker build succeeded"
+
+  # Aggregator that emits a single `Template validation` check name —
+  # the caller's job (`validate:` in each template's ci.yml) plus this
+  # job's name produces `validate / Template validation`, which is what
+  # template-repo branch protection has historically required.
+  #
+  # Why it's needed: the workflow was refactored from one job into
+  # validate-static + validate-runtime (with matrix-suffixed display
+  # names) for fork-PR security. The matrix names never match the
+  # original required-check name, so PR auto-merge silently hung in
+  # BLOCKED forever on every template repo (caught while shipping
+  # fixes for the boot-smoke gate, openclaw#11 + hermes#29).
+  #
+  # `if: always()` so it reports out even when validate-static fails —
+  # without that, GitHub marks the aggregator as SKIPPED and branch
+  # protection still blocks because the required check never reports
+  # a final state.
+  #
+  # Fork-PR semantics: validate-runtime is intentionally skipped on
+  # fork PRs (security gate). Treat `skipped` as a pass for the
+  # aggregator on forks so static-only coverage doesn't make every
+  # external PR un-mergeable.
+  template-validation:
+    name: Template validation
+    runs-on: ubuntu-latest
+    needs: [validate-static, validate-runtime]
+    if: always()
+    timeout-minutes: 1
+    steps:
+      - name: Aggregate
+        run: |
+          static="${{ needs.validate-static.result }}"
+          runtime="${{ needs.validate-runtime.result }}"
+          echo "validate-static:  $static"
+          echo "validate-runtime: $runtime"
+          if [ "$static" != "success" ]; then
+            echo "::error::validate-static did not succeed: $static"
+            exit 1
+          fi
+          if [ "$runtime" != "success" ] && [ "$runtime" != "skipped" ]; then
+            echo "::error::validate-runtime did not succeed: $runtime"
+            exit 1
+          fi
+          echo "::notice::Template validation aggregate passed (static=$static, runtime=$runtime)"


### PR DESCRIPTION
## Summary

The workflow was refactored from one \`validate\` job (display name \`Template validation\`) into matrix-named \`validate-static\` + \`validate-runtime\` jobs (\`(static)\` / \`(runtime)\` suffixes) for fork-PR security. That changed the GitHub check names from:

\`\`\`
validate / Template validation
\`\`\`

…to:

\`\`\`
validate / Template validation (static)
validate / Template validation (runtime)
\`\`\`

But every workspace-template repo's branch protection still requires the original (no-suffix) name. Since neither matrix-suffixed name matches, the required check **never reports a final state and PR auto-merge sits BLOCKED forever** — even with all CI green.

This adds a third aggregator job that emits the original check name so existing branch protection works again, no per-repo edits needed.

## How it works

\`\`\`yaml
template-validation:
  name: Template validation
  needs: [validate-static, validate-runtime]
  if: always()
  steps:
    - run: |
        # fail if static failed; treat skipped runtime (fork PRs) as pass
\`\`\`

- \`if: always()\` — runs even when validate-static fails. Without this, GitHub marks the aggregator SKIPPED and branch protection still blocks.
- Treats \`skipped\` as pass for validate-runtime — fork PRs intentionally skip runtime (security gate); without this, every external PR becomes un-mergeable.

## Why this matters

I caught it shipping the boot-smoke fixes for [openclaw#11](https://github.com/Molecule-AI/molecule-ai-workspace-template-openclaw/pull/11) and [hermes#29](https://github.com/Molecule-AI/molecule-ai-workspace-template-hermes/pull/29). Both PRs were stuck in BLOCKED with all real checks green. I patched the two repos' branch protection to use the matrix-suffixed names directly, but that's a per-repo workaround. This PR is the systemic fix — once landed, every template repo that points at \`@main\` gets the right check name automatically and the per-repo patches can be reverted.

## Test plan
- [ ] Workflow runs on this PR and produces a \`validate / Template validation\` check
- [ ] After merge, dispatching publish-image on a template branch shows the new check satisfying old-style branch protection
- [ ] Fork PRs still merge with runtime SKIPPED (aggregator passes on skipped runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)