### PR TITLE
feat(ci): add Trivy HIGH/CRITICAL gate before image push (RFC #388 PR-2)

### DIFF
--- a/.github/workflows/publish-template-image.yml
+++ b/.github/workflows/publish-template-image.yml
@@ -373,11 +373,55 @@ jobs:
           fi
           echo "::notice::✓ ${IMAGE} executor.execute() smoke passed (imports healthy, no runtime wedge)"
 
-      - name: Push image to GHCR (post-smoke)
-        # Now that the smoke test passed, push both tags. build-push-action
-        # reuses the cached build from the load step above, so this is fast
-        # — it's effectively a layer push, not a rebuild. Same build-args
-        # passed for cache key consistency.
+      - name: Trivy vulnerability scan (HIGH/CRITICAL gate)
+        # Belt-and-suspenders security gate: scan the locally-loaded image
+        # for known CVEs before promoting to :latest. Fails the workflow
+        # on any HIGH or CRITICAL finding so a vulnerable base layer
+        # never poisons :latest.
+        #
+        # Why pre-push: same reason boot smoke is pre-push — anything
+        # caught here means the bad bits never reach GHCR + never get
+        # pulled by a workspace. Catching post-push would leave a
+        # window where every fresh provision pulls a known-vulnerable
+        # image.
+        #
+        # Why HIGH+CRITICAL only: medium/low findings are too noisy in
+        # practice (~hundreds per Ubuntu base image, mostly unfixed
+        # apt CVEs that need an upstream Canonical respin). Promoting
+        # those to gate would drown signal in noise. RFC #388
+        # pre-implementation gate spec.
+        #
+        # ignore-unfixed=true follows the Trivy-recommended pattern for
+        # base-image scanning where unfixed CVEs in apt deps are
+        # operationally non-actionable until the next Canonical respin.
+        # Once Dockerfiles digest-pin the base (RFC #388 PR-2 second
+        # half), this becomes the matched pair: pin avoids surprise
+        # base-bumps; Trivy catches if the pinned digest itself
+        # accumulates fixable vulns.
+        #
+        # exit-code=1 + severity=HIGH,CRITICAL → workflow fails.
+        # No push happens because this step's failure short-circuits
+        # the next step.
+        uses: aquasecurity/trivy-action@0.28.0
+        env:
+          IMAGE: ${{ steps.tags.outputs.image }}:sha-${{ steps.tags.outputs.sha }}
+        with:
+          image-ref: ${{ steps.tags.outputs.image }}:sha-${{ steps.tags.outputs.sha }}
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          # vuln-type: keep default (os,library) — both apt-installed
+          # OS packages AND pip-installed Python deps get scanned.
+          # Catches both classes (e.g. a base CVE from an outdated
+          # libssl AND a pinned old version of `requests` with a
+          # known issue).
+
+      - name: Push image to GHCR (post-smoke + post-scan)
+        # Now that the smoke test AND the Trivy scan passed, push both
+        # tags. build-push-action reuses the cached build from the load
+        # step above, so this is fast — it's effectively a layer push,
+        # not a rebuild. Same build-args passed for cache key consistency.
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Summary

Belt-and-suspenders security gate inserted between boot-smoke and push-to-GHCR in the reusable \`publish-template-image.yml\`. Fails the publish on any HIGH or CRITICAL CVE in either the OS layer (apt deps) or the Python layer (pip deps). Image never reaches \`:latest\` if vulnerable, so no fresh workspace provision can pick up a known-bad layer.

## Why pre-push

Same logic as boot-smoke — anything that fails here never poisons \`:latest\`. Catching post-push leaves a window where every fresh provision pulls the vulnerable image. Sequencing: build (load-only) → lint → static-import smoke → boot smoke → **Trivy** → push.

## Why HIGH+CRITICAL only, with \`ignore-unfixed: true\`

Medium/low findings are too noisy in practice (~hundreds per Ubuntu base, mostly operationally non-actionable until the next Canonical respin). Promoting those to gate would drown signal in noise.

This becomes the matched pair with **RFC #388 PR-2's second half** (digest-pin \`python:3.11-slim\` base in each template's Dockerfile, deferred to per-template PRs):
- Digest-pin avoids surprise base-bumps.
- Trivy catches if the pinned digest itself accumulates fixable vulns over time.

## Scope

Applies to all 4 supported template repos automatically since they all consume this reusable workflow (claude-code, hermes, openclaw, codex per [PR #2536](https://github.com/Molecule-AI/molecule-core/pull/2556) prune set).

## Test plan

- [x] YAML validates
- [x] Diff is additive (one new step + comment update on the next step's name)
- [ ] CI green on this branch
- [ ] After merge: next template image rebuild exercises the gate. Expected outcome: existing template images pass (Ubuntu 22.04 base + python:3.11-slim layer have no current HIGH/CRITICAL fixed CVEs; if they do, the failure is a real find we should action separately).
- [ ] Spot-check: one operator-triggered \`workflow_dispatch\` against a clean template (codex is lightest) to confirm Trivy step runs and emits a clean result.

## Refs

- RFC: [#388](https://github.com/Molecule-AI/molecule-controlplane/issues/388) (v3 §2 finding: most of bake-smoke shipped via #2275; Trivy + digest-pin remain unique)
- Bench baseline (companion): [#390](https://github.com/Molecule-AI/molecule-controlplane/pull/390)
- Thin AMI skeleton (companion): [#391](https://github.com/Molecule-AI/molecule-controlplane/pull/391)

🤖 Generated with [Claude Code](https://claude.com/claude-code)