### PR TITLE
fix(publish): bump trivy-action 0.28.0 → 0.36.0 (0.28.0 yanked from registry)

### DIFF
--- a/.github/workflows/publish-template-image.yml
+++ b/.github/workflows/publish-template-image.yml
@@ -402,7 +402,7 @@ jobs:
         # exit-code=1 + severity=HIGH,CRITICAL → workflow fails.
         # No push happens because this step's failure short-circuits
         # the next step.
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.36.0
         env:
           IMAGE: ${{ steps.tags.outputs.image }}:sha-${{ steps.tags.outputs.sha }}
         with:


### PR DESCRIPTION
## Summary

`aquasecurity/trivy-action@0.28.0` was removed from the GitHub Actions registry — every workspace template's `publish-image` run is now red:

```
Unable to resolve action \`aquasecurity/trivy-action@0.28.0\`, unable to find version \`0.28.0\`
```

Currently observed on `Molecule-AI/molecule-ai-workspace-template-codex` main runs, will hit every other template the next time their publish-image fires (push to main, or runtime-published cascade).

## Fix

Bump pin to `0.36.0` — current latest, listed in the [GHA marketplace](https://github.com/marketplace/actions/aqua-security-trivy). Same step config; only the version tag changes.

## Test plan

- [x] YAML validates: `python3 -c "import yaml; yaml.safe_load(open('publish-template-image.yml'))"`
- [ ] Once merged, re-trigger a template's `publish-image` workflow and confirm Trivy step resolves the action and runs the scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)