### PR TITLE
fix(publish): trivy-action tag needs v prefix — bump 0.36.0 → v0.36.0

### DIFF
--- a/.github/workflows/publish-template-image.yml
+++ b/.github/workflows/publish-template-image.yml
@@ -402,7 +402,7 @@ jobs:
         # exit-code=1 + severity=HIGH,CRITICAL → workflow fails.
         # No push happens because this step's failure short-circuits
         # the next step.
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         env:
           IMAGE: ${{ steps.tags.outputs.image }}:sha-${{ steps.tags.outputs.sha }}
         with:


### PR DESCRIPTION
## Summary

Followup to #36. The non-v `0.36.0` tag doesn't exist on `aquasecurity/trivy-action` — only the `v`-prefixed `v0.36.0`. Re-triggered template-codex publish-image after #36 merged and got the same Unable-to-resolve error with the new version.

## Verified
- `gh api repos/aquasecurity/trivy-action/tags` returns `v0.36.0, v0.35.0, v0.34.0, …`
- Only one legacy non-v exists (`0.35.0`); nothing for 0.36

🤖 Generated with [Claude Code](https://claude.com/claude-code)